### PR TITLE
Fixing default config

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -1,6 +1,6 @@
 server:
   port: 5999
-  appRoot: "bucky"
+  appRoot: "/bucky"
 
 statsd:
   host: 'localhost'


### PR DESCRIPTION
Out of the box the BuckyServer starts up but all requests 404, this change adds the necessary leading slash to make the default config function out of the box.
