### PR TITLE
The value field send to influxDB should be numierc

### DIFF
--- a/lib/influxdb.coffee
+++ b/lib/influxdb.coffee
@@ -49,7 +49,7 @@ class Client
       data.push
         name: key,
         columns: ['value'],
-        points: [[val]]
+        points: [[parseFloat val]]
 
     JSON.stringify data
 


### PR DESCRIPTION
Just identified that the value send to InfluxDB is in string type, and it is not really useful as most of aggregate functions assumes numeric value. 
