### PR TITLE
add clustering support

### DIFF
--- a/start.js
+++ b/start.js
@@ -1,4 +1,17 @@
 #!/usr/bin/env node
 
-require("coffee-script");
-require("./server.coffee");
+var cluster = require('cluster');
+
+if (process.env.CLUSTER) {
+  if (cluster.isMaster) {
+    for (var i=0; i < parseInt(process.env.CLUSTER); i++) {
+      cluster.fork();
+    }
+  } else {
+    require("coffee-script");
+    require("./server.coffee");
+  }
+} else {
+  require("coffee-script");
+  require("./server.coffee");
+}


### PR DESCRIPTION
not sure if this feature is interesting to anyone else, but I'd like to see easier clustering support in bucky.

feature is managed through a `CLUSTER` environment variable that allows a number of processes to launch to be passed to the app on start. if multiple instances are launched, they run on `PORT`, `PORT + 1`, `PORT + 2`, `PORT + n`.
