### PR TITLE
Adding Influx v0.9 line protocol support

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -20,6 +20,8 @@ influxdb:
   retentionPolicy: 'default'
   # Acceptable version are: '0.8' and '0.9'
   version: '0.9'
+  # Only applies with version '0.9'
+  use_json: true
 
 
 modules:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bucky-server",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Server to collect stats from the client",
   "main": "./start.js",
   "bin": "./start.js",


### PR DESCRIPTION
This PR adds line protocol support when using influxdb version 0.9 and use_json is true.

Backward compatibility is kept for JSON for 0.8 and 0.9. This PR doesn't support tagging for v0.9 via line protocol. I'd be interested to hear any ideas on how to support them since there are different tags for different sites/organizations.
