### PR TITLE
Ignore requests from configured ip/hostname/fragment

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -1,6 +1,7 @@
 server:
   port: 5999
   appRoot: "/bucky"
+  ignoreIpFragment: '192.168.' # skip requests from this ip (or ip fragment). Used to e.g. filter internal traffic
 
 statsd:
   host: 'localhost'

--- a/modules/collectors.coffee
+++ b/modules/collectors.coffee
@@ -13,7 +13,7 @@ module.exports = ({app, logger, config}, next) ->
       isInternalRequest = true if req.ip.indexOf config.get('server.internalIpFragment').get() > -1
 
       if isInternalRequest
-        logger.log "#! > Skipping collectors for request from internal ip:", req.ip
+        logger.log "#! > Skipping collectors for ip:", req.ip
         return true
 
       for coll in collectors

--- a/modules/collectors.coffee
+++ b/modules/collectors.coffee
@@ -9,6 +9,13 @@ module.exports = ({app, logger, config}, next) ->
     return (req, res) ->
       res.send(204, '')
 
+      # filter internal requests
+      isInternalRequest = true if req.ip.indexOf config.get('server.internalIpFragment').get() > -1
+
+      if isInternalRequest
+        logger.log "#! > Skipping collectors for request from internal ip:", req.ip
+        return true
+
       for coll in collectors
         coll(req.body, {req, res})
 


### PR DESCRIPTION
Use case: Skip internal requests before they are passed to any of the collectors.
